### PR TITLE
replace fixed-size array with a static slice

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-pub static MOTIVATIONS: [&'static str; 66] = [
+pub static MOTIVATIONS: &[&str] = &[
     "don't worry. no one actually knows what they're doing."
   , "this is Hard Stuff, but you can do it!"
   , "getting started is hard, you did it, congratulations!"


### PR DESCRIPTION
In current stable rust, we can use static slice instead of an array.

I think that's better because we won't need to count the lines after every change.